### PR TITLE
feat: Update History Panel session list and chart Y-axis

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -184,27 +184,34 @@ export function HistoryPanel() {
     }
   }, [filteredSessions, groupBy, projects, startDate, endDate])
 
-  const chartOptions = {
-    responsive: true,
-    plugins: {
-      legend: {
-        position: 'top' as const,
-      },
-      title: {
-        display: true,
-        text: groupBy === 'project' ? 'Hours by Project' : 'Hours per Day'
-      },
-    },
-    scales: {
-      y: {
-        beginAtZero: true,
+  const chartOptions = useMemo(() => {
+    const maxDataValue = chartData.datasets[0].data.length > 0
+      ? Math.max(...chartData.datasets[0].data)
+      : 0
+
+    return {
+      responsive: true,
+      plugins: {
+        legend: {
+          position: 'top' as const,
+        },
         title: {
           display: true,
-          text: 'Hours'
+          text: groupBy === 'project' ? 'Hours by Project' : 'Hours per Day'
+        },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: 'Hours'
+          },
+          max: maxDataValue <= 5 ? 5 : undefined
         }
       }
     }
-  }
+  }, [chartData, groupBy])
 
   const handleProjectToggle = (projectId: number) => {
     setSelectedProjectIds(prev => 

--- a/src/components/SessionsTable.tsx
+++ b/src/components/SessionsTable.tsx
@@ -103,7 +103,7 @@ export function SessionsTable({ projectId, showAllProjects = false, sessions: ex
         </h3>
       </div>
       
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto overflow-y-auto max-h-[29rem]">
         <table className="w-full">
           <thead className="bg-gray-50">
             <tr>


### PR DESCRIPTION
This commit introduces two changes to the History Panel:

1.  The session list is now limited to a height of 8 sessions. A scrollbar is added if the number of sessions exceeds this limit. This is achieved by adding a max-height and overflow-y-auto to the table container.

2.  The chart's Y-axis is now adjusted based on the data. If the maximum value of the data is less than or equal to 5 hours, the Y-axis maximum is set to 5 hours. Otherwise, it scales automatically to fit the data.